### PR TITLE
fix create_missing_network_objects to create range objects when needed

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 commit = True
 tag = True
 

--- a/lib/algosec-sdk/version.rb
+++ b/lib/algosec-sdk/version.rb
@@ -2,5 +2,5 @@
 
 # Gem version defined here
 module ALGOSEC_SDK
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end


### PR DESCRIPTION
Up until now, only HOST object types was supported thus causing erros when a user was trying to create a flow with CIDR/Range objects.

This fixes the `create_missing_network_objects` to identify the missing objects and create them as HOST/Range objects as needed.