### PR TITLE
create missing objects if they are not found by exact name search

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ Metrics/LineLength:
   Max: 120
 
 Metrics/ModuleLength:
-  Max: 220
+  Max: 300
 
 Metrics/ParameterLists:
   Max: 6

--- a/lib/algosec-sdk/helpers/business_flow_helper.rb
+++ b/lib/algosec-sdk/helpers/business_flow_helper.rb
@@ -366,8 +366,14 @@ module ALGOSEC_SDK
       # TODO: Add unitests that objects are being create only once (if the same object is twice in the incoming list)
       network_object_names = Set.new(network_object_names)
       ipv4_or_subnet_objects = network_object_names.map do |object_name|
-        if get_network_object_type(object_name)
-          search_network_object(object_name, NetworkObjectSearchType::EXACT).empty? ? object_name : nil
+        next unless get_network_object_type(object_name)
+        search_results = search_network_object(object_name, NetworkObjectSearchType::EXACT)
+        if search_results.empty?
+          # nothing was found, mark the object for creation
+          object_name
+        else
+          # if no object named the same way, mark it for creation
+          search_results.any? { |result| result['name'] == object_name } ? nil : object_name
         end
       end.compact
 

--- a/spec/unit/helpers/business_flow_helper_spec.rb
+++ b/spec/unit/helpers/business_flow_helper_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe ALGOSEC_SDK::BusinessFlowHelper do
         allow(@client).to receive(:create_network_object).and_return('created_object')
         create_missing_objects
       end
-      it 'creates the object if it was not found by search' do
+      it 'creates the object if there are no search results' do
         expect(@client).to receive(:search_network_object).with(
           missing_object,
           ALGOSEC_SDK::NetworkObjectSearchType::EXACT
@@ -341,8 +341,20 @@ RSpec.describe ALGOSEC_SDK::BusinessFlowHelper do
         ).and_return('created_object')
         expect(create_missing_objects).to eq ['created_object']
       end
+      it 'creates the object if it was not found by exact name in the search results' do
+        expect(@client).to receive(:search_network_object).with(
+          missing_object,
+          ALGOSEC_SDK::NetworkObjectSearchType::EXACT
+        ).and_return([{ 'name' => 'some-other-name-for-the-object' }])
+        expect(@client).to receive(:create_network_object).with(
+          missing_object_type, missing_object, missing_object
+        ).and_return('created_object')
+        expect(create_missing_objects).to eq ['created_object']
+      end
       it 'avoids object creation if it is found' do
-        expect(@client).to receive(:search_network_object).with(anything, anything).and_return([anything])
+        expect(@client).to receive(:search_network_object).with(anything, anything).and_return(
+          [{ 'name' => missing_object }]
+        )
         expect(@client).not_to receive(:create_network_object)
         expect(create_missing_objects).to eq []
       end


### PR DESCRIPTION
That way, they will surly exist by name when creating the application flow.